### PR TITLE
fix: fix check for props.env instead of props.startkey

### DIFF
--- a/cjs.cjs
+++ b/cjs.cjs
@@ -17,7 +17,7 @@ module.exports = function (props) {
       const isProd = props?.isProd ?? options.minify
 
       for (const k in process.env) {
-        if (k.startsWith(`${props?.env ?? "ESB"}_`))
+        if (k.startsWith(`${props?.startkey ?? "ESB"}_`))
           define[`process.env.${k}`] = JSON.stringify(process.env[k])
       }
 

--- a/esm.mjs
+++ b/esm.mjs
@@ -15,7 +15,7 @@ export default function env(props) {
       const isProd = props?.isProd ?? options.minify
 
       for (const k in process.env) {
-        if (k.startsWith(`${props?.env ?? "ESB"}_`))
+        if (k.startsWith(`${props?.startkey ?? "ESB"}_`))
           define[`process.env.${k}`] = JSON.stringify(process.env[k])
       }
 


### PR DESCRIPTION
There was a problem: due to a README, it's possible to set `startkey` parameter to set custom envvar prefix. But in the code, there was a check for `env` parameter, that led to unexpected behavior.